### PR TITLE
action playback

### DIFF
--- a/docs/demonstrations.md
+++ b/docs/demonstrations.md
@@ -43,8 +43,6 @@ The `demo.hdf5` file is structured as follows.
 
   - env (attribute) - environment name on which demos were collected
 
-    
-
   - demo1 (group) - group for the first demonstration (every demonstration has a group)
 
     - model_file (attribute) - name of corresponding model xml in `models` directory
@@ -62,8 +60,6 @@ The `demo.hdf5` file is structured as follows.
     - left_dpos (dataset) - end effector delta position command for left arm (bimanual robot only)
 
     - left_dquat (dataset) - end effector delta rotation command for left arm (bimanual robot only)
-
-      
 
   - demo2 (group) - group for the second demonstration
 
@@ -108,7 +104,32 @@ Note that the rendering window must be active for these commands to work.
 | Twist mouse about an axis | rotate arm about a corresponding axis |
 |      ESC (keyboard)       |                 quit                  |
 
+### Example
 
+First make sure that you have installed cloned and installed robosuite using
 
+```bash
+git clone https://github.com/StanfordVL/robosuite.git
+cd robosuite
+pip install -e .
+```
 
- 
+Next, navigate to the scripts directory and run `collect_human_demonstrations.py` to collect a set of demonstrations using your keyboard, and press the ESC key when you are finished collecting.
+
+```bash
+cd robosuite/scripts
+python collect_human_demonstrations.py
+```
+
+Now we can replay the demonstrations. You should see a new demonstration folder that was created under `robosuite/robosuite/models/assets/demonstrations`. We can use the `playback_demonstrations_from_hdf5.py` script to playback the demonstrations that were collected.
+
+```bash
+python playback_demonstrations_from_hdf5.py --folder PATH_TO_DEMO_FOLDER
+```
+
+This will replay the demonstrations by forcing the collected internal mujoco simulator states one by one. Optionally, you can also replay the collection actions in an open loop fashion by passing the `--use-actions`flag to the script.
+
+```bash
+python playback_demonstrations_from_hdf5.py --folder PATH_TO_DEMO_FOLDER --use-actions
+```
+

--- a/robosuite/scripts/playback_demonstrations_from_hdf5.py
+++ b/robosuite/scripts/playback_demonstrations_from_hdf5.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "--use_actions", 
+        "--use-actions", 
         action='store_true',
     )
     args = parser.parse_args()

--- a/robosuite/scripts/playback_demonstrations_from_hdf5.py
+++ b/robosuite/scripts/playback_demonstrations_from_hdf5.py
@@ -2,6 +2,12 @@
 A convenience script to playback random demonstrations from
 a set of demonstrations stored in a hdf5 file.
 
+Arguments:
+    --folder (str): Path to demonstrations
+    --use_actions (optional): If this flag is provided, the actions are played back 
+        through the MuJoCo simulator, instead of loading the simulator states
+        one by one.
+
 Example:
     $ python playback_demonstrations_from_hdf5.py --folder ../models/assets/demonstrations/SawyerPickPlace/
 """
@@ -22,6 +28,10 @@ if __name__ == "__main__":
         default=os.path.join(
             robosuite.models.assets_root, "demonstrations/SawyerNutAssembly"
         ),
+    )
+    parser.add_argument(
+        "--use_actions", 
+        action='store_true',
     )
     args = parser.parse_args()
 
@@ -58,15 +68,39 @@ if __name__ == "__main__":
         env.reset()
         xml = postprocess_model_xml(model_xml)
         env.reset_from_xml_string(xml)
+        env.sim.reset()
         env.viewer.set_camera(0)
 
         # load the flattened mujoco states
         states = f["data/{}/states".format(ep)].value
 
-        # force the sequence of internal mujoco states one by one
-        for state in states:
-            env.sim.set_state_from_flattened(state)
+        if args.use_actions:
+
+            # load the initial state
+            env.sim.set_state_from_flattened(states[0])
             env.sim.forward()
-            env.render()
+
+            # load the actions and play them back open-loop
+            jvels = f["data/{}/joint_velocities".format(ep)].value
+            grip_acts = f["data/{}/gripper_actuations".format(ep)].value
+            actions = np.concatenate([jvels, grip_acts], axis=1)
+            num_actions = actions.shape[0]
+
+            for j, action in enumerate(actions):
+                env.step(action)
+                env.render()
+
+                if j < num_actions - 1:
+                    # ensure that the actions deterministically lead to the same recorded states
+                    state_playback = env.sim.get_state().flatten()
+                    assert(np.all(np.equal(states[j + 1], state_playback)))
+
+        else:
+
+            # force the sequence of internal mujoco states one by one
+            for state in states:
+                env.sim.set_state_from_flattened(state)
+                env.sim.forward()
+                env.render()
 
     f.close()

--- a/robosuite/wrappers/data_collection_wrapper.py
+++ b/robosuite/wrappers/data_collection_wrapper.py
@@ -87,11 +87,15 @@ class DataCollectionWrapper(Wrapper):
         """
         t1, t2 = str(time.time()).split(".")
         state_path = os.path.join(self.ep_directory, "state_{}_{}.npz".format(t1, t2))
+        if hasattr(self.env, "unwrapped"):
+            env_name = self.env.unwrapped.__class__.__name__
+        else:
+            env_name = self.env.__class__.__name__
         np.savez(
             state_path,
             states=np.array(self.states),
             action_infos=self.action_infos,
-            env=self.env.unwrapped.__class__.__name__,
+            env=env_name,
         )
         self.states = []
         self.action_infos = []


### PR DESCRIPTION
- Added functionality for deterministic open loop playback of actions from demonstrations. Note that this only applies to new demonstrations that are collected with these changes (old demonstrations will not playback correctly).
- Fixed a bug where we were possible dropping a few intermediate (s, a) pairs during data collection.