### PR TITLE
copy observations before returning them

### DIFF
--- a/robosuite/environments/baxter.py
+++ b/robosuite/environments/baxter.py
@@ -279,7 +279,7 @@ class BaxterEnv(MujocoEnv):
                     for x in self._ref_gripper_right_joint_vel_indexes
                 ]
             )
-            di["right_eef_pos"] = self.sim.data.site_xpos[self.right_eef_site_id]
+            di["right_eef_pos"] = np.array(self.sim.data.site_xpos[self.right_eef_site_id])
             di["right_eef_quat"] = T.convert_quat(
                 self.sim.data.get_body_xquat("right_hand"), to="xyzw"
             )
@@ -300,7 +300,7 @@ class BaxterEnv(MujocoEnv):
                     for x in self._ref_gripper_left_joint_vel_indexes
                 ]
             )
-            di["left_eef_pos"] = self.sim.data.site_xpos[self.left_eef_site_id]
+            di["left_eef_pos"] = np.array(self.sim.data.site_xpos[self.left_eef_site_id])
             di["left_eef_quat"] = T.convert_quat(
                 self.sim.data.get_body_xquat("left_hand"), to="xyzw"
             )

--- a/robosuite/environments/baxter_lift.py
+++ b/robosuite/environments/baxter_lift.py
@@ -245,19 +245,19 @@ class BaxterLift(BaxterEnv):
         # low-level object information
         if self.use_object_obs:
             # position and rotation of object
-            cube_pos = self.sim.data.body_xpos[self.cube_body_id]
+            cube_pos = np.array(self.sim.data.body_xpos[self.cube_body_id])
             cube_quat = T.convert_quat(
                 self.sim.data.body_xquat[self.cube_body_id], to="xyzw"
             )
             di["cube_pos"] = cube_pos
             di["cube_quat"] = cube_quat
 
-            di["l_eef_xpos"] = self._l_eef_xpos
-            di["r_eef_xpos"] = self._r_eef_xpos
-            di["handle_1_xpos"] = self._handle_1_xpos
-            di["handle_2_xpos"] = self._handle_2_xpos
-            di["l_gripper_to_handle"] = self._l_gripper_to_handle
-            di["r_gripper_to_handle"] = self._r_gripper_to_handle
+            di["l_eef_xpos"] = np.array(self._l_eef_xpos)
+            di["r_eef_xpos"] = np.array(self._r_eef_xpos)
+            di["handle_1_xpos"] = np.array(self._handle_1_xpos)
+            di["handle_2_xpos"] = np.array(self._handle_2_xpos)
+            di["l_gripper_to_handle"] = np.array(self._l_gripper_to_handle)
+            di["r_gripper_to_handle"] = np.array(self._r_gripper_to_handle)
 
             di["object-state"] = np.concatenate(
                 [

--- a/robosuite/environments/baxter_peg_in_hole.py
+++ b/robosuite/environments/baxter_peg_in_hole.py
@@ -223,14 +223,14 @@ class BaxterPegInHole(BaxterEnv):
         # low-level object information
         if self.use_object_obs:
             # position and rotation of cylinder and hole
-            hole_pos = self.sim.data.body_xpos[self.hole_body_id]
+            hole_pos = np.array(self.sim.data.body_xpos[self.hole_body_id])
             hole_quat = T.convert_quat(
                 self.sim.data.body_xquat[self.hole_body_id], to="xyzw"
             )
             di["hole_pos"] = hole_pos
             di["hole_quat"] = hole_quat
 
-            cyl_pos = self.sim.data.body_xpos[self.cyl_body_id]
+            cyl_pos = np.array(self.sim.data.body_xpos[self.cyl_body_id])
             cyl_quat = T.convert_quat(
                 self.sim.data.body_xquat[self.cyl_body_id], to="xyzw"
             )

--- a/robosuite/environments/sawyer.py
+++ b/robosuite/environments/sawyer.py
@@ -265,7 +265,7 @@ class SawyerEnv(MujocoEnv):
                 [self.sim.data.qvel[x] for x in self._ref_gripper_joint_vel_indexes]
             )
 
-            di["eef_pos"] = self.sim.data.site_xpos[self.eef_site_id]
+            di["eef_pos"] = np.array(self.sim.data.site_xpos[self.eef_site_id])
             di["eef_quat"] = T.convert_quat(
                 self.sim.data.get_body_xquat("right_hand"), to="xyzw"
             )

--- a/robosuite/environments/sawyer_nut_assembly.py
+++ b/robosuite/environments/sawyer_nut_assembly.py
@@ -430,7 +430,7 @@ class SawyerNutAssembly(SawyerEnv):
                     continue
 
                 obj_str = str(self.item_names_org[i]) + "0"
-                obj_pos = self.sim.data.body_xpos[self.obj_body_id[obj_str]]
+                obj_pos = np.array(self.sim.data.body_xpos[self.obj_body_id[obj_str]])
                 obj_quat = T.convert_quat(
                     self.sim.data.body_xquat[self.obj_body_id[obj_str]], to="xyzw"
                 )

--- a/robosuite/environments/sawyer_pick_place.py
+++ b/robosuite/environments/sawyer_pick_place.py
@@ -472,7 +472,7 @@ class SawyerPickPlace(SawyerEnv):
                     continue
 
                 obj_str = str(self.item_names_org[i]) + "0"
-                obj_pos = self.sim.data.body_xpos[self.obj_body_id[obj_str]]
+                obj_pos = np.array(self.sim.data.body_xpos[self.obj_body_id[obj_str]])
                 obj_quat = T.convert_quat(
                     self.sim.data.body_xquat[self.obj_body_id[obj_str]], to="xyzw"
                 )


### PR DESCRIPTION
- There can be subtle bugs with modifying certain observation keys in-place if copies are not returned. Fixing some of those issues by ensuring copies are returned for those keys.