### PR TITLE
fix reset issue for sawyer and baxter with grippers

### DIFF
--- a/robosuite/environments/baxter.py
+++ b/robosuite/environments/baxter.py
@@ -96,12 +96,12 @@ class BaxterEnv(MujocoEnv):
 
         if self.has_gripper_right:
             self.sim.data.qpos[
-                self._ref_joint_gripper_right_actuator_indexes
+                self._ref_gripper_right_joint_pos_indexes
             ] = self.gripper_right.init_qpos
 
         if self.has_gripper_left:
             self.sim.data.qpos[
-                self._ref_joint_gripper_left_actuator_indexes
+                self._ref_gripper_left_joint_pos_indexes
             ] = self.gripper_left.init_qpos
 
     def _get_reference(self):

--- a/robosuite/environments/sawyer.py
+++ b/robosuite/environments/sawyer.py
@@ -112,7 +112,7 @@ class SawyerEnv(MujocoEnv):
 
         if self.has_gripper:
             self.sim.data.qpos[
-                self._ref_joint_gripper_actuator_indexes
+                self._ref_gripper_joint_pos_indexes
             ] = self.gripper.init_qpos
 
     def _get_reference(self):


### PR DESCRIPTION
This fixes an issue in reset function.
In the original code, `self._ref_joint_gripper_right_actuator_indexes` and `self._ref_joint_gripper_left_actuator_indexes` contain indexes of the left wrist.
`self._ref_gripper_right_joint_pos_indexes` and `self._ref_gripper_left_joint_pos_indexes` should be used instead of them.